### PR TITLE
Add filter query parameter to webpart

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Search People from Organization Directory and show live persona card on hover.
 |Properties to search | text | No | By default **FirstName,LastName,WorkEmail,Department** are used for search. You can add custom properties separated by comma.|
 |Properties to sent as clear text | text | No | By default if the search key has empty spaces, its replaced with **+** before sending it to the search query. The search properties mentioned here will be sent without the empty space replacement.|
 |Results per page | number | Yes | Number of people result to be displayed per page. Max of **20** is allowed, default of **10** is set.|
+|Filter Query| text | No | Additional search filter such as `Department:IT` or `BaseOfficeLocation:London`.|
 
 ## Contributors
 

--- a/src/webparts/directory/DirectoryWebPart.manifest.json
+++ b/src/webparts/directory/DirectoryWebPart.manifest.json
@@ -24,7 +24,8 @@
       "title": "Directory",
       "searchFirstName":  0,
       "searchProps": "FirstName,LastName,PreferredName,WorkEmail,Department",
-      "pageSize": 10
+      "pageSize": 10,
+      "filterQuery": ""
     }
   }]
 }

--- a/src/webparts/directory/DirectoryWebPart.ts
+++ b/src/webparts/directory/DirectoryWebPart.ts
@@ -32,6 +32,7 @@ export interface IDirectoryWebPartProps {
   clearTextSearchProps: string;
   pageSize: number;
   justifycontent: boolean;
+  filterQuery: string;
 }
 
 export enum AppMode {
@@ -67,6 +68,7 @@ export default class DirectoryWebPart extends BaseClientSideWebPart<IDirectoryWe
         useSpaceBetween: this.properties.justifycontent,
         isDarkTheme: this._isDarkTheme,
         hasTeamsContext: !!this.context.sdks.microsoftTeams,
+        filterQuery: this.properties.filterQuery,
       }
     );
 
@@ -203,6 +205,13 @@ export default class DirectoryWebPart extends BaseClientSideWebPart<IDirectoryWe
                   min: 2,
                   step: 2,
                   value: this.properties.pageSize,
+                }),
+                PropertyPaneTextField('filterQuery', {
+                  label: strings.FilterQueryLabel,
+                  description: strings.FilterQueryDesc,
+                  value: this.properties.filterQuery,
+                  multiline: false,
+                  resizable: false,
                 }),
               ],
             },

--- a/src/webparts/directory/components/DirectoryHook.tsx
+++ b/src/webparts/directory/components/DirectoryHook.tsx
@@ -137,16 +137,30 @@ const DirectoryHook: React.FC<IDirectoryProps> = (props) => {
     let users = null;
     if (initialSearch) {
       if (props.searchFirstName)
-        users = await _services.searchUsersNew('', `FirstName:a*`, false);
-      else users = await _services.searchUsersNew('a', '', true);
+        users = await _services.searchUsersNew(
+          '',
+          `FirstName:a*${props.filterQuery ? ` AND ${props.filterQuery}` : ''}`,
+          false
+        );
+      else
+        users = await _services.searchUsersNew(
+          'a',
+          props.filterQuery ? `${props.filterQuery}` : '',
+          true
+        );
     } else {
       if (props.searchFirstName)
         users = await _services.searchUsersNew(
           '',
-          `FirstName:${alphaKey}*`,
+          `FirstName:${alphaKey}*${props.filterQuery ? ` AND ${props.filterQuery}` : ''}`,
           false
         );
-      else users = await _services.searchUsersNew(`${alphaKey}`, '', true);
+      else
+        users = await _services.searchUsersNew(
+          `${alphaKey}`,
+          props.filterQuery ? `${props.filterQuery}` : '',
+          true
+        );
     }
     setstate({
       ...state,
@@ -208,7 +222,10 @@ const DirectoryHook: React.FC<IDirectoryProps> = (props) => {
           });
         }
         console.log(qryText);
-        const users = await _services.searchUsersNew('', qryText, false);
+        const finalQuery = props.filterQuery
+          ? `${qryText} AND ${props.filterQuery}`
+          : qryText;
+        const users = await _services.searchUsersNew('', finalQuery, false);
         setstate({
           ...state,
           searchText: searchText,

--- a/src/webparts/directory/components/IDirectoryProps.ts
+++ b/src/webparts/directory/components/IDirectoryProps.ts
@@ -13,4 +13,5 @@ export interface IDirectoryProps {
   useSpaceBetween?: boolean;
   isDarkTheme: boolean;
   hasTeamsContext: boolean;
+  filterQuery?: string;
 }

--- a/src/webparts/directory/loc/en-us.js
+++ b/src/webparts/directory/loc/en-us.js
@@ -12,6 +12,8 @@ define([], function() {
     "SearchPropsDesc": "Enter the properties separated by comma to be used for search",
     "ClearTextSearchPropsLabel":"Properties whose values are not replaced",
     "ClearTextSearchPropsDesc":"Enter the properties separated by comma to be sent as it is without replacing space with '+'",
-    "PagingLabel": "Results per page"
+    "PagingLabel": "Results per page",
+    "FilterQueryLabel": "Filter Query",
+    "FilterQueryDesc": "Additional search filter e.g. Department:IT OR BaseOfficeLocation:London"
   }
 });

--- a/src/webparts/directory/loc/mystrings.d.ts
+++ b/src/webparts/directory/loc/mystrings.d.ts
@@ -12,6 +12,8 @@ declare interface IDirectoryWebPartStrings {
   ClearTextSearchPropsLabel: string;
   ClearTextSearchPropsDesc: string;
   PagingLabel: string;
+  FilterQueryLabel: string;
+  FilterQueryDesc: string;
 }
 
 declare module 'DirectoryWebPartStrings' {


### PR DESCRIPTION
## Summary
- add `filterQuery` property to web part configuration
- pass new property to DirectoryHook and apply additional filter clause in queries
- localize filter query property label and description
- document filter query option

## Testing
- `npm test` *(fails: gulp not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b24a93448328bc636ebcb4b14909