### PR TITLE
Fix persona card width and text wrapping

### DIFF
--- a/src/webparts/directory/components/PersonaCard/PersonaCard.module.scss
+++ b/src/webparts/directory/components/PersonaCard/PersonaCard.module.scss
@@ -4,15 +4,15 @@
   display: inline-block;
   margin-top: 15px;
   margin-right: 15px;
-  min-width: 300px;
-  max-width: 300px;
+  min-width: 350px;
+  max-width: 350px;
   vertical-align: top;
 }
 .documentCard {
   border-color: $ms-color-themeDark;
   border-top-width: 5px;
   width: 100%;
-  max-width: 350px;
+  max-width: 400px;
   height: 120px;
   display: flex;
   flex-direction: row;
@@ -29,13 +29,9 @@
 }
 
 .textOverflow {
-  word-break: break-all;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  word-break: break-word;
+  overflow-wrap: break-word;
   white-space: normal;
-  display: -webkit-box;
-  -webkit-line-clamp: 1;
-  -webkit-box-orient: vertical;
 }
 .personaDetails {
   display: flex;

--- a/src/webparts/directory/components/PersonaCard/PersonaCard.tsx
+++ b/src/webparts/directory/components/PersonaCard/PersonaCard.tsx
@@ -11,6 +11,7 @@ import {
   Card,
   Subtitle1,
   Text,
+  mergeClasses,
 } from '@fluentui/react-components';
 import {
   Call16Filled,
@@ -93,7 +94,7 @@ export class PersonaCard extends React.Component<
             {this.props.profileProperties.Department}
           </Text>
           {this.props.profileProperties.Email && (
-            <div className={(styles.textOverflow, styles.others)}>
+            <div className={mergeClasses(styles.textOverflow, styles.others)}>
               <Mail16Filled style={{ fontSize: '12px' }} />
               <span style={{ marginLeft: 5, fontSize: '12px' }}>
                 {this.props.profileProperties.Email}
@@ -112,7 +113,7 @@ export class PersonaCard extends React.Component<
             ''
           )}
           {this.props.profileProperties.Location ? (
-            <div className={(styles.textOverflow, styles.others)}>
+            <div className={mergeClasses(styles.textOverflow, styles.others)}>
               <Location16Filled style={{ fontSize: '12px' }} />
               <span style={{ marginLeft: 5, fontSize: '12px' }}>
                 {' '}


### PR DESCRIPTION
## Summary
- widen persona card layout
- allow multi-line text on contact fields
- apply classes correctly for email and location rows

## Testing
- `npm test` *(fails: gulp not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859afbc48d0832882040e3b4af7b4ee